### PR TITLE
Share LoginStatus enum across FFI boundary

### DIFF
--- a/complex objects/cargo/Cargo.lock
+++ b/complex objects/cargo/Cargo.lock
@@ -1,14 +1,3 @@
-[root]
-name = "greetings"
-version = "0.1.1"
-dependencies = [
- "jni 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "ascii"
 version = "0.7.1"
@@ -68,6 +57,17 @@ dependencies = [
 name = "gcc"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "greetings"
+version = "0.1.1"
+dependencies = [
+ "jni 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "jni"

--- a/complex objects/cargo/src/categories.rs
+++ b/complex objects/cargo/src/categories.rs
@@ -29,7 +29,6 @@ use utils::{
 };
 
 #[derive(Debug)]
-#[repr(C)]
 pub struct CategoryManager {
     conn: Arc<Mutex<Connection>>,
     uri: String
@@ -218,7 +217,6 @@ impl CategoryManager {
 }
 
 #[derive(Debug, Clone)]
-#[repr(C)]
 pub struct Category {
     pub id: isize,
     pub name: String,

--- a/complex objects/cargo/src/categories.rs
+++ b/complex objects/cargo/src/categories.rs
@@ -19,7 +19,6 @@ use std::sync::{
 };
 
 use rusqlite::Connection;
-use time::Timespec;
 
 use items::Item;
 use utils::{
@@ -318,14 +317,14 @@ pub unsafe extern "C" fn category_list_item_at(category_list: *const Vec<Categor
 
 #[no_mangle]
 pub unsafe extern "C" fn add_category(category_list: *mut Vec<Category>, category: *const Category) {
-    let mut category_list = &mut*category_list;
+    let category_list = &mut*category_list;
     let category = &*category;
     category_list.push((*category).clone())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn category_add_item(category: *mut Category, item: *const Item) {
-    let mut category = &mut*category;
+    let category = &mut*category;
     let item = &*item;
     category.items.push((*item).clone());
 }

--- a/complex objects/cargo/src/db.rs
+++ b/complex objects/cargo/src/db.rs
@@ -17,7 +17,7 @@ use std::sync::{
 };
 
 use rusqlite::{
-    Connection
+    Connection,
 };
 
 use logins::{
@@ -32,7 +32,6 @@ use utils::{
 };
 
 #[derive(Debug)]
-#[repr(C)]
 pub struct Store {
     pub conn: Arc<Mutex<Connection>>,
     pub uri: String,

--- a/complex objects/cargo/src/items.rs
+++ b/complex objects/cargo/src/items.rs
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn item_get_description(item: *const Item) -> *mut c_char 
 
 #[no_mangle]
 pub unsafe extern "C" fn item_set_description(item: *mut Item, description: *const c_char) {
-    let mut item = &mut*item;
+    let item = &mut*item;
     item.description = c_char_to_string(description);
 }
 
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn item_get_due_date(item: *const Item) -> *mut i64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn item_set_due_date(item: *mut Item, due_date: *const size_t) {
-    let mut item = &mut*item;
+    let item = &mut*item;
     if !due_date.is_null() {
         item.due_date = Some(Timespec::new(due_date as i64, 0));
     } else {
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn item_get_is_complete(item: *const Item) -> c_int {
 
 #[no_mangle]
 pub unsafe extern "C" fn item_set_is_complete(item: *mut Item, is_complete: size_t) {
-    let mut item = &mut*item;
+    let item = &mut*item;
     let is_complete = is_complete as usize;
     match is_complete {
         0 => item.is_complete = false,

--- a/complex objects/cargo/src/items.rs
+++ b/complex objects/cargo/src/items.rs
@@ -24,7 +24,6 @@ use utils::{
 };
 
 #[derive(Debug, Clone)]
-#[repr(C)]
 pub struct Item {
     pub id: Option<isize>,
     pub description: String,

--- a/complex objects/cargo/src/lib.rs
+++ b/complex objects/cargo/src/lib.rs
@@ -9,7 +9,6 @@
 // specific language governing permissions and limitations under the License.
 
 extern crate libc;
-extern crate libsqlite3_sys;
 extern crate rusqlite;
 extern crate time;
 extern crate uuid;

--- a/complex objects/cargo/src/lib.rs
+++ b/complex objects/cargo/src/lib.rs
@@ -9,6 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 extern crate libc;
+extern crate libsqlite3_sys;
 extern crate rusqlite;
 extern crate time;
 extern crate uuid;
@@ -18,4 +19,3 @@ pub mod categories;
 pub mod items;
 pub mod utils;
 pub mod db;
-

--- a/complex objects/cargo/src/logins.h
+++ b/complex objects/cargo/src/logins.h
@@ -3,6 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
  
 #include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+    Valid = 0,
+    UnknownUsername = 1,
+    IncorrectPassword = 2,
+    Invalid = 3,
+} LoginStatus;
+
+
 
 struct login;
 struct login_manager;
@@ -10,9 +20,10 @@ struct login_manager;
 void login_destroy(struct login* data);
 
 struct login* create_login(const struct login_manager* manager, const char* username, const char* password);
-const size_t validate_login(const struct login_manager* manager, const char* username, const char* password);
+const LoginStatus validate_login(const struct login_manager* manager, const char* username, const char* password);
 
 // Accessors for Login properties
+const LoginStatus login_is_valid(const struct login* data);
 const size_t login_get_id(const struct login* data);
 const char* login_get_username(const struct login* data);
 const char* login_get_password(const struct login* data);
@@ -22,4 +33,3 @@ const size_t login_get_time_created(const struct login* data);
 const size_t login_get_time_last_used(const struct login* data);
 const size_t login_get_time_password_changed(const struct login* data);
 const size_t login_get_times_used(const struct login* data);
-const size_t login_is_valid(const struct login* data);

--- a/complex objects/cargo/src/logins.rs
+++ b/complex objects/cargo/src/logins.rs
@@ -116,7 +116,7 @@ impl LoginManager {
 }
 
 #[derive(Debug, Copy, Clone)]
-#[repr(u8)]
+#[repr(C)]
 pub enum LoginStatus {
     Valid,
     UnknownUsername,

--- a/complex objects/cargo/src/logins.rs
+++ b/complex objects/cargo/src/logins.rs
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn validate_login(manager: *const Arc<LoginManager>, usern
     match manager.fetch_login(uname, pword) {
         Some(mut login) => {
             manager.update_login_as_used(&mut login);
-            login.is_valid.clone()
+            login.is_valid
         },
         None => LoginStatus::IncorrectPassword
     }
@@ -210,7 +210,7 @@ pub unsafe extern "C" fn login_get_guid(login: *const Login) -> *mut c_char {
 
 #[no_mangle]
 pub unsafe extern "C" fn login_set_guid(login: *mut Login, guid: *const c_char) {
-    let mut login = &mut *login;
+    let login = &mut *login;
     login.guid = c_char_to_string(guid);
 }
 
@@ -244,5 +244,5 @@ pub unsafe extern "C" fn login_get_times_used(login: *const Login) -> c_int {
 #[no_mangle]
 pub unsafe extern "C" fn login_is_valid(login: *const Login) -> LoginStatus {
     let login = &*login;
-    login.is_valid.clone()
+    login.is_valid
 }

--- a/complex objects/ios/ComplexRust.xcodeproj/project.pbxproj
+++ b/complex objects/ios/ComplexRust.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		7B9F013E1F827D7B000407E5 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9F013D1F827D7B000407E5 /* Category.swift */; };
 		7BB2204D1F8F976C00ACD7AF /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB2204C1F8F976C00ACD7AF /* Item.swift */; };
 		7BB220541F8FA72500ACD7AF /* RustObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB220531F8FA72500ACD7AF /* RustObject.swift */; };
-		7BBC4D041FA3409500CACA11 /* libgreetings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9F01291F794F49000407E5 /* libgreetings.a */; };
+		7BCBDDEA1FAB6019001F8B06 /* libgreetings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9F01291F794F49000407E5 /* libgreetings.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,7 +63,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B9F01281F794F3B000407E5 /* libresolv.tbd in Frameworks */,
-				7BBC4D041FA3409500CACA11 /* libgreetings.a in Frameworks */,
+				7BCBDDEA1FAB6019001F8B06 /* libgreetings.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/complex objects/ios/ComplexRust.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/complex objects/ios/ComplexRust.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,12 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/emilytoop/Development/greetings/complex objects/ios/ComplexRust/ComplexRust/ComplexRust-Bridging-Header.h">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/emilytoop/Development/greetings/complex objects/ios/ComplexRust/ComplexRust/logins.h">
-   </FileRef>
-   <FileRef
       location = "self:ComplexRust.xcodeproj">
    </FileRef>
 </Workspace>

--- a/complex objects/ios/ComplexRust/Store/Logins/Login.swift
+++ b/complex objects/ios/ComplexRust/Store/Logins/Login.swift
@@ -62,8 +62,6 @@ class Login: RustObject {
 
     var isValid: LoginStatus {
         let loginStatus = login_is_valid(raw)
-        print("Login Status: \(loginStatus)")
         return LoginStatus(rawValue: loginStatus.rawValue) ?? .invalid
-//        return LoginStatus.valid
     }
 }

--- a/complex objects/ios/ComplexRust/Store/Logins/Login.swift
+++ b/complex objects/ios/ComplexRust/Store/Logins/Login.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum LoginStatus: Int {
+enum LoginStatus: UInt32 {
     case valid = 0
     case unknownUsername = 1
     case incorrectPassword = 2
@@ -61,6 +61,9 @@ class Login: RustObject {
     }
 
     var isValid: LoginStatus {
-        return LoginStatus(rawValue: login_is_valid(raw)) ?? .invalid
+        let loginStatus = login_is_valid(raw)
+        print("Login Status: \(loginStatus)")
+        return LoginStatus(rawValue: loginStatus.rawValue) ?? .invalid
+//        return LoginStatus.valid
     }
 }

--- a/complex objects/ios/ComplexRust/Store/Logins/LoginManager.swift
+++ b/complex objects/ios/ComplexRust/Store/Logins/LoginManager.swift
@@ -10,7 +10,7 @@ class LoginManager: RustObject {
     }
 
     func validateLogin(withUsername username: String, andPassword password: String) -> LoginStatus {
-        return LoginStatus(rawValue: validate_login(self.raw, username, password)) ?? .invalid
+        return LoginStatus(rawValue: validate_login(self.raw, username, password).rawValue) ?? .invalid
     }
 
     func createLogin(withUsername username: String, andPassword password: String) -> Login? {


### PR DESCRIPTION
Create `LoginStatus` enum inside rust library and return from `validate_login` and `login.is_valid` functions.
Create C equivalent `LoginStatus` enum inside `logins.h` and amend header for `validate_login` and `login_is_valid`.
Convert C `LoginStatus` enum to swift enum.

#10 