### PR TITLE
Move from SQLite to Mentat DB

### DIFF
--- a/complex/cargo/Cargo.lock
+++ b/complex/cargo/Cargo.lock
@@ -216,13 +216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "list"
 version = "0.1.0"
 dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -607,6 +611,7 @@ dependencies = [
  "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -641,6 +646,7 @@ dependencies = [
 name = "toodle"
 version = "0.1.0"
 dependencies = [
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "ffi-utils 0.1.0",
  "list 0.1.0",
  "store 0.1.0",
@@ -689,6 +695,9 @@ dependencies = [
 name = "uuid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "vcpkg"

--- a/complex/cargo/Cargo.lock
+++ b/complex/cargo/Cargo.lock
@@ -1,7 +1,38 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ascii"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -19,9 +50,28 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "combine"
@@ -33,9 +83,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "edn"
+version = "0.1.0"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peg 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "enum-set"
+version = "0.0.6"
+source = "git+https://github.com/rnewman/enum-set#35f2699f121f2cd4f061a871e84022ddfdd35c36"
+
+[[package]]
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
+version = "0.11.0"
+source = "git+https://github.com/rnewman/error-chain?branch=rnewman/sync#f00b30d09b3f177bc8616a9c80315e90ccd0fd74"
+dependencies = [
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ffi-utils"
@@ -63,6 +154,14 @@ version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "itertools"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jni"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +186,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -135,8 +239,292 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "matches"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat"
+version = "0.4.0"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_core"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_db"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_parser_utils"
+version = "0.1.0"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_query"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_query_algebrizer"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_query_parser"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_query_projector"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_query_sql"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_query_translator"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_sql"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_tx"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_tx_parser"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "num"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ordered-float"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "peg"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pretty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -154,6 +542,23 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "regex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rusqlite"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,12 +570,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "store"
 version = "0.1.0"
 dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -194,6 +644,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uuid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,8 +683,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -217,30 +708,85 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
+"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
+"checksum edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
+"checksum enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)" = "<none>"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)" = "<none>"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f3f75d7cf195a7eedb0611efe8684b55c6c7264afe3d8bc00b704f061c0fdf"
 "checksum jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cffc930ce6a38a4013e30567b559bdc79f601013ba4a81e65dbda9207263efd4"
 "checksum jni-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "de0aaaba8809ab8d83a53fe2b313b996b79e8632b855eae9f70ad4323dca91b8"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum libsqlite3-sys 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "370090ad578ba845a3ad4f383ceb3deba7abd51ab1915ad1f2c982cc6035e31c"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
+"checksum maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "22593015b8df7747861c69c28acd32589fb96c1686369f3b661d12e409d4cf65"
+"checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
+"checksum num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8fd0f8dbb4c0960998958a796281d88c16fbe68d87b1baa6f31e2979e81fd0bd"
+"checksum num-complex 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "503e668405c5492d67cf662a81e05be40efe2e6bcf10f7794a07bd9865e704e6"
+"checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
+"checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
+"checksum num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7cb72a95250d8a370105c828f388932373e0e94414919891a0f945222310fe"
+"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58d25b6c0e47b20d05226d288ff434940296e7e2f8b877975da32f862152241f"
+"checksum peg 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36a474cba42744afe0f223e9d4263594b3387f172e512259c72d2011e477c4fb"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum pretty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023e184a8dc60fde1d6e0916637835ad61d68fe83a190bf74977e8e4dca9d24e"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffaf393ccdac5580092a4d8eb2edffbffe9a8c4484c62d8a0fcac99bc3718566"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+"checksum tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7810162bc0a2eb2dc9a9bfd16ddb2d1f6022df3236d1478937bfadcb12385e"
+"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
+"checksum typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5934776c3ac1bea4a9d56620d6bf2d483b20d394e49581db40f187e1118ff667"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cfec50b0842181ba6e713151b72f4ec84a6a7e2c9c8a8a3ffc37bb1cd16b231"
+"checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/complex/cargo/Cargo.lock
+++ b/complex/cargo/Cargo.lock
@@ -597,13 +597,16 @@ name = "store"
 version = "0.1.0"
 dependencies = [
  "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/complex/cargo/Cargo.toml
+++ b/complex/cargo/Cargo.toml
@@ -8,6 +8,9 @@ description = "Cross Platform Library for providing To Do List data"
 name = "toodle"
 crate-type = ["staticlib", "cdylib"]
 
+[dependencies]
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
+
 [dependencies.ffi-utils]
 path = "ffi-utils"
 

--- a/complex/cargo/list/Cargo.lock
+++ b/complex/cargo/list/Cargo.lock
@@ -217,6 +217,7 @@ name = "list"
 version = "0.1.0"
 dependencies = [
  "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/complex/cargo/list/Cargo.lock
+++ b/complex/cargo/list/Cargo.lock
@@ -1,7 +1,38 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ascii"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -19,9 +50,28 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "combine"
@@ -33,9 +83,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "edn"
+version = "0.1.0"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peg 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "enum-set"
+version = "0.0.6"
+source = "git+https://github.com/rnewman/enum-set#35f2699f121f2cd4f061a871e84022ddfdd35c36"
+
+[[package]]
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
+version = "0.11.0"
+source = "git+https://github.com/rnewman/error-chain?branch=rnewman/sync#f00b30d09b3f177bc8616a9c80315e90ccd0fd74"
+dependencies = [
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ffi-utils"
@@ -63,6 +154,14 @@ version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "itertools"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jni"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +186,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -135,8 +239,292 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "matches"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat"
+version = "0.4.0"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_core"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_db"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_parser_utils"
+version = "0.1.0"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_query"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_query_algebrizer"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_query_parser"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_query_projector"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_query_sql"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_query_translator"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_sql"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mentat_tx"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "mentat_tx_parser"
+version = "0.0.1"
+source = "git+https://github.com/mozilla/mentat.git?rev=5558820#55588209c296272ae30cc8be96c0aa179337c2ef"
+dependencies = [
+ "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+]
+
+[[package]]
+name = "num"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ordered-float"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "peg"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pretty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -154,6 +542,23 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "regex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rusqlite"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,12 +570,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "store"
 version = "0.1.0"
 dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,6 +635,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uuid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,8 +674,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -208,30 +699,85 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
+"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
+"checksum edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
+"checksum enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)" = "<none>"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)" = "<none>"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f3f75d7cf195a7eedb0611efe8684b55c6c7264afe3d8bc00b704f061c0fdf"
 "checksum jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cffc930ce6a38a4013e30567b559bdc79f601013ba4a81e65dbda9207263efd4"
 "checksum jni-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "de0aaaba8809ab8d83a53fe2b313b996b79e8632b855eae9f70ad4323dca91b8"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum libsqlite3-sys 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "370090ad578ba845a3ad4f383ceb3deba7abd51ab1915ad1f2c982cc6035e31c"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
+"checksum maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "22593015b8df7747861c69c28acd32589fb96c1686369f3b661d12e409d4cf65"
+"checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)" = "<none>"
+"checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
+"checksum num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8fd0f8dbb4c0960998958a796281d88c16fbe68d87b1baa6f31e2979e81fd0bd"
+"checksum num-complex 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "503e668405c5492d67cf662a81e05be40efe2e6bcf10f7794a07bd9865e704e6"
+"checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
+"checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
+"checksum num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7cb72a95250d8a370105c828f388932373e0e94414919891a0f945222310fe"
+"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58d25b6c0e47b20d05226d288ff434940296e7e2f8b877975da32f862152241f"
+"checksum peg 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36a474cba42744afe0f223e9d4263594b3387f172e512259c72d2011e477c4fb"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum pretty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023e184a8dc60fde1d6e0916637835ad61d68fe83a190bf74977e8e4dca9d24e"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffaf393ccdac5580092a4d8eb2edffbffe9a8c4484c62d8a0fcac99bc3718566"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+"checksum tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7810162bc0a2eb2dc9a9bfd16ddb2d1f6022df3236d1478937bfadcb12385e"
+"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
+"checksum typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5934776c3ac1bea4a9d56620d6bf2d483b20d394e49581db40f187e1118ff667"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cfec50b0842181ba6e713151b72f4ec84a6a7e2c9c8a8a3ffc37bb1cd16b231"
+"checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/complex/cargo/list/Cargo.lock
+++ b/complex/cargo/list/Cargo.lock
@@ -216,13 +216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "list"
 version = "0.1.0"
 dependencies = [
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -607,6 +610,7 @@ dependencies = [
  "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -680,6 +684,9 @@ dependencies = [
 name = "uuid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "vcpkg"

--- a/complex/cargo/list/Cargo.lock
+++ b/complex/cargo/list/Cargo.lock
@@ -597,13 +597,16 @@ name = "store"
 version = "0.1.0"
 dependencies = [
  "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mentat 0.4.0 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
  "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?rev=5558820)",
+ "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/complex/cargo/list/Cargo.toml
+++ b/complex/cargo/list/Cargo.toml
@@ -7,9 +7,10 @@ authors = ["Emily Toop <etoop@mozilla.com>"]
 jni = { version = "0.5", default-features = false }
 
 [dependencies]
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
+libc = "0.2.32"
 time = "0.1.38"
 uuid = { version = "0.5", features = ["v4"] }
-libc = "0.2.32"
 
 [dependencies.edn]
 git = "https://github.com/mozilla/mentat.git"

--- a/complex/cargo/list/Cargo.toml
+++ b/complex/cargo/list/Cargo.toml
@@ -8,8 +8,20 @@ jni = { version = "0.5", default-features = false }
 
 [dependencies]
 time = "0.1.38"
-uuid = { version = "0.4", features = ["v4"] }
+uuid = { version = "0.5", features = ["v4"] }
 libc = "0.2.32"
+
+[dependencies.edn]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
+
+[dependencies.mentat]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
+
+[dependencies.mentat_core]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
 
 [dependencies.store]
 path = "../store"

--- a/complex/cargo/list/src/errors.rs
+++ b/complex/cargo/list/src/errors.rs
@@ -10,20 +10,14 @@
 
 #![allow(dead_code)]
 
-use rusqlite;
-
-use mentat::errors as mentat;
+use store::errors as store_error;
 
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;
     }
 
-    foreign_links {
-        Rusqlite(rusqlite::Error);
-    }
-
     links {
-        MentatError(mentat::Error, mentat::ErrorKind);
+        StoreError(store_error::Error, store_error::ErrorKind);
     }
 }

--- a/complex/cargo/list/src/items.rs
+++ b/complex/cargo/list/src/items.rs
@@ -9,7 +9,6 @@
 // specific language governing permissions and limitations under the License.
 
 use libc::size_t;
-use std::any::Any;
 use std::os::raw::{
     c_char,
     c_int,

--- a/complex/cargo/list/src/items.rs
+++ b/complex/cargo/list/src/items.rs
@@ -25,6 +25,7 @@ use labels::Label;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Item {
+    pub id: Option<i64>,
     pub uuid: String,
     pub name: String,
     pub due_date: Option<Timespec>,
@@ -41,6 +42,7 @@ impl Drop for Item {
 #[no_mangle]
 pub extern "C" fn item_new() -> *mut Item {
     let item = Item{
+        id: None,
         uuid: "".to_string(),
         name: "".to_string(),
         due_date: None,

--- a/complex/cargo/list/src/labels.rs
+++ b/complex/cargo/list/src/labels.rs
@@ -8,10 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::os::raw::{
-    c_char,
-};
-use std::rc::Rc;
+use std::os::raw::c_char;
 
 use mentat_core::TypedValue;
 

--- a/complex/cargo/list/src/labels.rs
+++ b/complex/cargo/list/src/labels.rs
@@ -11,6 +11,9 @@
 use std::os::raw::{
     c_char,
 };
+use std::rc::Rc;
+
+use mentat_core::TypedValue;
 
 use ffi_utils::strings::{
     string_to_c_char,
@@ -26,6 +29,21 @@ pub struct Label {
 impl Drop for Label {
     fn drop(&mut self) {
         println!("{:?} is being deallocated", self);
+    }
+}
+
+impl Label {
+    pub fn from_row(row: &Vec<TypedValue>) -> Option<Label> {
+        let label_row: Vec<String> = row.iter().filter_map(|col| {
+            match col {
+                &TypedValue::String(ref val) => Some(val.to_string()),
+                _ => None
+            }
+        }).collect();
+        Some(Label {
+            name: label_row[0].to_owned(),
+            color: label_row[1].to_owned(),
+        })
     }
 }
 

--- a/complex/cargo/list/src/labels.rs
+++ b/complex/cargo/list/src/labels.rs
@@ -19,9 +19,14 @@ use ffi_utils::strings::{
     string_to_c_char,
     c_char_to_string,
 };
+use store::{
+    Entity,
+    ToInner
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Label {
+    pub id: Option<Entity>,    // id should not be leaked outside of the library
     pub name: String,
     pub color: String
 }
@@ -34,15 +39,10 @@ impl Drop for Label {
 
 impl Label {
     pub fn from_row(row: &Vec<TypedValue>) -> Option<Label> {
-        let label_row: Vec<String> = row.iter().filter_map(|col| {
-            match col {
-                &TypedValue::String(ref val) => Some(val.to_string()),
-                _ => None
-            }
-        }).collect();
         Some(Label {
-            name: label_row[0].to_owned(),
-            color: label_row[1].to_owned(),
+            id: row[0].clone().to_inner(),
+            name: row[1].clone().to_inner(),
+            color: row[2].clone().to_inner()
         })
     }
 }

--- a/complex/cargo/list/src/lib.rs
+++ b/complex/cargo/list/src/lib.rs
@@ -44,7 +44,11 @@ pub mod items;
 use labels::Label;
 use ffi_utils::strings::c_char_to_string;
 use items::Item;
-use store::Store;
+use store::{
+    Entity,
+    Store,
+    ToInner
+};
 
 #[derive(Debug)]
 #[repr(C)]
@@ -70,30 +74,22 @@ impl ListManager {
         let schema = r#"[{  :db/ident     :label/name
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one
-    :db/unique :db.unique/value
+    :db/unique :db.unique/identity
     :db/fulltext true },
  {  :db/ident     :label/color
     :db/valueType :db.type/string
-    :db/cardinality :db.cardinality/one },
- {  :db/ident     :label/items
-    :db/valueType :db.type/ref
-    :db/cardinality :db.cardinality/many }]"#;
+    :db/cardinality :db.cardinality/one }]"#;
         let _ = self.write_connection().transact(schema);
     }
 
     pub fn create_label(&mut self, name: String, color: String) -> Option<Label> {
-        let query = format!(r#"[{{
-            :label/name "{0}"
-            :label/color "{1}"
-            }}]"#, &name, &color);
-        println!("{:?}", query);
+        let query = format!("[{{ :label/name \"{0}\" :label/color \"{1}\" }}]", &name, &color);
         let res = self.write_connection().transact(&query);
-        println!("res: {:?}", res);
         self.fetch_label(&name)
     }
 
     pub fn fetch_label(&self, name: &String) -> Option<Label> {
-        let query = r#"[:find ?name, ?color
+        let query = r#"[:find ?eid, ?name, ?color
             :in ?name
             :where
             [?eid :label/name ?name]
@@ -120,12 +116,11 @@ impl ListManager {
     }
 
     pub fn fetch_labels(&self) -> Vec<Label> {
-        let query = r#"[:find ?name, ?color
+        let query = r#"[:find ?eid, ?name, ?color
             :where
             [?eid :label/name ?name]
             [?eid :label/color ?color]
         ]"#;
-        println!("{:?}", query);
         let result = Arc::clone(&self.store).query(query);
         match result {
             Ok(rel) => {
@@ -143,22 +138,19 @@ impl ListManager {
     }
 
     pub fn fetch_labels_for_item(&self, item_uuid: &Uuid) -> Vec<Label> {
-        println!("fetch_labels_for_item");
-        let query = r#"[:find ?name, ?color
+        let query = r#"[:find ?l, ?name, ?color
             :in ?item_uuid
             :where
             [?l :label/name ?name]
             [?l :label/color ?color]
-            [?l :label/items ?i]
+            [?i :item/labels ?l]
             [?i :item/uuid ?item_uuid]
         ]"#;
-        println!("query {:?}, {:?}", query, item_uuid);
         let result = Arc::clone(&self.store).query_args(query, &[&(&"?item_uuid".to_string(), &item_uuid)]);
         match result {
             Ok(rel) => {
                 if let QueryResults::Rel(rows) = rel {
-                    println!("rows {:?}", rows);
-                    rows.iter().map(|row| Label::from_row(&row).unwrap()).collect()
+                    rows.iter().filter_map(|row| Label::from_row(&row)).collect()
                 } else {
                     println!("no labels for item {:?}", item_uuid);
                     vec![]
@@ -175,7 +167,7 @@ impl ListManager {
         let schema = r#"[{  :db/ident     :item/uuid
             :db/valueType :db.type/uuid
             :db/cardinality :db.cardinality/one
-            :db/unique :db.unique/identity
+            :db/unique :db.unique/value
             :db/index true },
         {  :db/ident     :item/name
             :db/valueType :db.type/string
@@ -194,53 +186,54 @@ impl ListManager {
     }
 
     pub fn fetch_items_with_label(&self, label: &Label) -> Vec<Item> {
-        // let sql = r#"SELECT uuid, name, created_at, due_date, completion_date
-        //              FROM items LEFT JOIN item_labels on items.uuid=item_label.item_uuid
-        //              WHERE item_labels.label_name=?"#;
-        // let conn = self.store.read_connection();
-        // let mut stmt = conn.prepare(sql).unwrap();
-        // let mut item_iter = stmt.query_map(&[&label.name], |row| {
-        //     let uuid: String = row.get(0);
-        //     Item {
-        //         uuid: uuid.clone(),
-        //         name: row.get(1),
-        //         due_date: row.get(2),
-        //         completion_date: row.get(3),
-        //         labels: self.fetch_labels_for_item(&uuid)
-        //     }
-        // }).unwrap();
-
-        let mut item_list: Vec<Item> = Vec::new();
-        // while let Some(result) = item_iter.next() {
-        //     if let Some(i) = result.ok() {
-        //         item_list.push(i);
-        //     }
-        // }
-        item_list
+        let query = r#"[:find ?uuid
+            :in ?label
+            :where
+            [?eid :item/uuid ?uuid]
+            [?eid :item/labels ?l]
+            [?l :label/name ?label]
+        ]"#;
+        let result = Arc::clone(&self.store).query_args(query, &[&(&"?label".to_string(), &label.name)]);
+        match result {
+            Ok(rel) => {
+                if let QueryResults::Rel(rows) = rel {
+                    rows.iter().filter_map(|row| {
+                        let uuid: Uuid = row[0].to_owned().to_inner();
+                        self.fetch_item(&uuid)
+                    }).collect()
+                } else {
+                    println!("no items for label {:?}", label.name);
+                    vec![]
+                }
+            },
+            Err(e) => {
+                println!("Failed to fetch items for {:?}: {}", label.name, e);
+                vec![]
+            },
+        }
     }
 
     pub fn fetch_item(&self, uuid: &Uuid) -> Option<Item> {
-        println!("fetching item {}", uuid);
-        let query = r#"[:find ?eid, ?uuid, ?name, ?due_date, ?completion_date
+        let query = r#"[:find ?eid, ?uuid, ?name
             :in ?uuid
             :where
             [?eid :item/uuid ?uuid]
             [?eid :item/name ?name]
-            [?eid :item/due_date ?due_date]
-            [?eid :item/completion_date ?completion_date]
         ]"#;
-        println!("{:?} {:?}", query, uuid);
         let result = Arc::clone(&self.store).query_args(query, &[&(&"?uuid".to_string(), &uuid)]);
         match result {
             Ok(rel) => {
                 if let QueryResults::Rel(rows) = rel {
-                    println!("rows {:?}", rows);
                     if !rows.is_empty() {
-                        let mut item = Item::from_row(&rows[0]).unwrap();
-                        println!("fetching labels for item: {:?}", item);
-                        item.labels = self.fetch_labels_for_item(&uuid);
-                        println!("returning item: {:?}", item);
-                        Some(item)
+                        let row = &rows[0];
+                        Some(Item{
+                            id: row[0].clone().to_inner(),
+                            uuid: row[1].clone().to_inner(),
+                            name: row[2].clone().to_inner(),
+                            due_date: self.fetch_date_for_item("due_date", &uuid),
+                            completion_date: self.fetch_date_for_item("completion_date", &uuid),
+                            labels: self.fetch_labels_for_item(&uuid),
+                        })
                     } else {
                         None
                     }
@@ -255,11 +248,44 @@ impl ListManager {
         }
     }
 
+    fn fetch_date_for_item(&self, attr: &str, item_id: &Uuid) -> Option<Timespec> {
+        let query = format!(r#"[:find ?{0}
+            :in ?uuid
+            :where
+            [?eid :item/{0} ?{0}]
+            [?eid :item/uuid ?uuid]
+        ]"#, attr);
+        let result = Arc::clone(&self.store).query_args(&query, &[&(&"?uuid".to_string(), &item_id)]);
+        match result {
+            Ok(rel) => {
+                if let QueryResults::Rel(rows) = rel {
+                    if !rows.is_empty() {
+                        let row = &rows[0];
+                        let date: Option<Timespec> = row[0].clone().to_inner();
+                        date
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            },
+            Err(e) => {
+                None
+            }
+        }
+    }
+
     pub fn create_item(&mut self, item: &Item) -> Uuid {
-        let label_str = item.labels.iter().map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
+        let label_str = item.labels.iter().filter_map(|label| {
+            if label.id.is_some() {
+                Some(format!("{}",label.id.to_owned().unwrap().id))
+            } else {
+                None
+            }
+        }).collect::<Vec<String>>().join(", ");
         let tmp_uuid = uuid::Uuid::new_v4().hyphenated().to_string();
         let item_uuid = Uuid::parse_str(&tmp_uuid).unwrap();
-        // println!("item uuid: {:?}", item_uuid);
         let mut query = format!(r#"[{{
             :item/uuid #uuid "{0}"
             :item/name "{1}"
@@ -275,45 +301,45 @@ impl ListManager {
                 "#, &query, &micro_seconds);
         }
         if !label_str.is_empty() {
-            query = format!(r#"{0}:item/labels ["{1}"]
+            query = format!(r#"{0}:item/labels [{1}]
                 "#, &query, &label_str);
         }
         query = format!("{0}}}]", &query);
-        println!("query: {}", query);
         let res = self.write_connection().transact(&query);
-        // println!("res: {:?}", res);
         item_uuid
     }
 
     pub fn create_and_fetch_item(&mut self, item: &Item) -> Option<Item> {
-        println!("Creating item {:?}", item);
         let item_uuid = self.create_item(&item);
-        println!("Fetching item {:?}", item_uuid);
         self.fetch_item(&item_uuid)
     }
 
     pub fn update_item(&mut self, item: &Item, name: Option<String>, due_date: Option<Timespec>, completion_date: Option<Timespec>, labels: Option<&Vec<Label>>) {
-        let item_id = item.id.expect("item must have ID to be updated");
+        let item_id = item.id.to_owned().expect("item must have ID to be updated");
         let mut transaction = vec![];
 
         if let Some(name) = name {
             if item.name != name {
-                transaction.push(format!("[:db/add {0} :item/name {1}]", &item_id, name));
+                transaction.push(format!("[:db/add {0} :item/name {1}]", &item_id.id, name));
             }
         }
         if item.due_date != due_date {
             if let Some(date) = due_date {
-                transaction.push(format!("[:db/add {:?} :item/due_date {:?}]", &item_id, date));
+                let micro_seconds = date.sec * 1000000;
+                transaction.push(format!("[:db/add {:?} :item/due_date #instmicros {}]", &item_id.id, &micro_seconds));
             } else {
-                transaction.push(format!("[:db/retract {:?} :item/due_date {:?}]", &item_id, item.due_date.unwrap()));
+                let micro_seconds = item.due_date.unwrap().sec * 1000000;
+                transaction.push(format!("[:db/retract {:?} :item/due_date #instmicros {}]", &item_id.id, &micro_seconds));
             }
         }
 
         if item.completion_date != completion_date {
-            if let Some(date) = due_date {
-                transaction.push(format!("[:db/add {:?} :item/completion_date {:?}]", &item_id, date));
+            if let Some(date) = completion_date {
+                let micro_seconds = date.sec * 1000000;
+                transaction.push(format!("[:db/add {:?} :item/completion_date #instmicros {}]", &item_id.id, &micro_seconds));
             } else {
-                transaction.push(format!("[:db/retract {:?} :item/completion_date {:?}]", &item_id, item.completion_date.unwrap()));
+                let micro_seconds = item.completion_date.unwrap().sec * 1000000;
+                transaction.push(format!("[:db/retract {:?} :item/completion_date #instmicros {}]", &item_id.id, &micro_seconds));
             }
         }
 
@@ -322,15 +348,15 @@ impl ListManager {
 
             let labels_to_add = new_labels.iter().filter(|label| !existing_labels.contains(label) ).map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
             if !labels_to_add.is_empty() {
-                transaction.push(format!("[:db/add {0} :item/labels [\"{1}\"]]", &item_id, labels_to_add));
+                transaction.push(format!("[:db/add {0} :item/labels [\"{1}\"]]", &item_id.id, labels_to_add));
             }
             let labels_to_remove = existing_labels.iter().filter(|label| !new_labels.contains(label) ).map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
             if !labels_to_remove.is_empty() {
-                transaction.push(format!("[:db/retract {0} :item/labels [\"{1}\"]]", &item_id, labels_to_remove));
+                transaction.push(format!("[:db/retract {0} :item/labels [\"{1}\"]]", &item_id.id, labels_to_remove));
             }
         }
         let query = format!("[{0}]", transaction.join(""));
-        let _ = self.write_connection().transact(&query);
+        let res = self.write_connection().transact(&query);
     }
 }
 
@@ -394,6 +420,7 @@ mod test {
 
     use mentat_core::Uuid;
     use time::now_utc;
+    use uuid;
 
 
     fn list_manager() -> ListManager {
@@ -443,12 +470,15 @@ mod test {
     #[test]
     fn test_create_label() {
         let mut manager = list_manager();
-        let l = Label {
-            name: "test".to_string(),
-            color: "#000000".to_string()
-        };
-        let label = manager.create_label(l.name.clone(), l.color.clone());
-        assert_eq!(label, Some(l));
+        let name = "test".to_string();
+        let color = "#000000".to_string();
+
+        let label = manager.create_label(name.clone(), color.clone());
+        assert!(label.is_some());
+        let label = label.unwrap();
+        assert!(label.id.is_some());
+        assert_eq!(label.name, name);
+        assert_eq!(label.color, color);
     }
 
     #[test]
@@ -480,17 +510,8 @@ mod test {
     #[test]
     fn test_create_item() {
         let mut manager = list_manager();
-        let l = Label {
-            name: "label1".to_string(),
-            color: "#000000".to_string()
-        };
-        let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
-
-        let l2 = Label {
-            name: "label2".to_string(),
-            color: "#000000".to_string()
-        };
-        let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
 
         let date = now_utc().to_timespec();
         let i = Item {
@@ -502,8 +523,6 @@ mod test {
             labels: vec![label, label2]
         };
 
-        println!("creating and fetching item {:?}", i);
-
         let item = manager.create_and_fetch_item(&i).expect("expected an item");
         assert!(!item.uuid.is_nil());
         assert_eq!(item.name, i.name);
@@ -514,292 +533,301 @@ mod test {
         assert_eq!(item.labels, i.labels);
     }
 
-    // #[test]
-    // fn test_create_item_no_due_date() {
-    //     let mut manager = list_manager();
-    //     let l = Label {
-    //         name: "label1".to_string(),
-    //         color: "#000000".to_string()
-    //     };
-    //     let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
+    #[test]
+    fn test_create_item_no_due_date() {
+        let mut manager = list_manager();
+        let l = Label {
+            id: None,
+            name: "label1".to_string(),
+            color: "#000000".to_string()
+        };
+        let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
 
-    //     let l2 = Label {
-    //         name: "label2".to_string(),
-    //         color: "#000000".to_string()
-    //     };
-    //     let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
+        let l2 = Label {
+            id: None,
+            name: "label2".to_string(),
+            color: "#000000".to_string()
+        };
+        let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
 
-    //     let date = now_utc().to_timespec();
-    //     let i = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item".to_string(),
-    //         due_date: None,
-    //         completion_date: Some(date.clone()),
-    //         labels: vec![label, label2]
-    //     };
+        let date = now_utc().to_timespec();
+        let i = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item".to_string(),
+            due_date: None,
+            completion_date: Some(date.clone()),
+            labels: vec![label, label2]
+        };
 
-    //     let item = manager.create_and_fetch_item(&i).expect("expected an item");
-    //     assert!(item.uuid.len() > 0);
-    //     assert_eq!(item.name, i.name);
-    //     assert_eq!(item.due_date, i.due_date);
-    //     let completion_date = item.completion_date.expect("expecting a completion date");
-    //     assert_eq!(completion_date.sec, date.sec);
-    //     assert_eq!(item.labels, i.labels);
-    // }
+        let item = manager.create_and_fetch_item(&i).expect("expected an item");
+        assert!(!item.uuid.is_nil());
+        assert_eq!(item.name, i.name);
+        assert_eq!(item.due_date, i.due_date);
+        let completion_date = item.completion_date.expect("expecting a completion date");
+        assert_eq!(completion_date.sec, date.sec);
+        assert_eq!(item.labels, i.labels);
+    }
 
-    // #[test]
-    // fn test_create_item_no_completion_date() {
-    //     let mut manager = list_manager();
-    //     let l = Label {
-    //         name: "label1".to_string(),
-    //         color: "#000000".to_string()
-    //     };
-    //     let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
+    #[test]
+    fn test_create_item_no_completion_date() {
+        let mut manager = list_manager();
+        let l = Label {
+            id: None,
+            name: "label1".to_string(),
+            color: "#000000".to_string()
+        };
+        let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
 
-    //     let l2 = Label {
-    //         name: "label2".to_string(),
-    //         color: "#000000".to_string()
-    //     };
-    //     let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
+        let l2 = Label {
+            id: None,
+            name: "label2".to_string(),
+            color: "#000000".to_string()
+        };
+        let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
 
-    //     let date = now_utc().to_timespec();
-    //     let i = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item".to_string(),
-    //         due_date: Some(date.clone()),
-    //         completion_date: None,
-    //         labels: vec![label, label2]
-    //     };
+        let date = now_utc().to_timespec();
+        let i = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item".to_string(),
+            due_date: Some(date.clone()),
+            completion_date: None,
+            labels: vec![label, label2]
+        };
 
-    //     let item = manager.create_and_fetch_item(&i).expect("expected an item");
-    //     assert!(item.uuid.len() > 0);
-    //     assert_eq!(item.name, i.name);
-    //     let due_date = item.due_date.expect("expecting a due date");
-    //     assert_eq!(due_date.sec, date.sec);
-    //     assert_eq!(item.completion_date, i.completion_date);
-    //     assert_eq!(item.labels, i.labels);
-    // }
+        let item = manager.create_and_fetch_item(&i).expect("expected an item");
+        assert!(!item.uuid.is_nil());
+        assert_eq!(item.name, i.name);
+        let due_date = item.due_date.expect("expecting a due date");
+        assert_eq!(due_date.sec, date.sec);
+        assert_eq!(item.completion_date, i.completion_date);
+        assert_eq!(item.labels, i.labels);
+    }
 
-    // #[test]
-    // fn test_fetch_item() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let mut created_item = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label]
-    //     };
+    #[test]
+    fn test_fetch_item() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let mut created_item = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label]
+        };
 
-    //     created_item.uuid = manager.create_item(&created_item);
-    //     let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
-    //     assert_eq!(fetched_item, created_item);
+        created_item.uuid = manager.create_item(&created_item);
+        let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
+        assert_eq!(fetched_item.uuid, created_item.uuid);
+        assert_eq!(fetched_item.name, created_item.name);
+        assert_eq!(fetched_item.due_date, created_item.due_date);
+        assert_eq!(fetched_item.completion_date, created_item.completion_date);
+        assert_eq!(fetched_item.labels, created_item.labels);
 
-    //     let fetched_item = manager.fetch_item(&"doesn't exist".to_string());
-    //     assert_eq!(fetched_item, None);
-    // }
+        let tmp_uuid = uuid::Uuid::new_v4().hyphenated().to_string();
+        let item_uuid = Uuid::parse_str(&tmp_uuid).unwrap();
+        let fetched_item = manager.fetch_item(&item_uuid);
+        assert_eq!(fetched_item, None);
+    }
 
-    // #[test]
-    // fn test_fetch_labels_for_item() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    #[test]
+    fn test_fetch_labels_for_item() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-    //     let mut item1 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 1".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label, label2, label3]
-    //     };
+        let mut item1 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 1".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label, label2, label3]
+        };
 
-    //     item1.uuid = manager.create_item(&item1);
+        item1.uuid = manager.create_item(&item1);
 
-    //     let fetched_labels = manager.fetch_labels_for_item(&item1.uuid);
-    //     assert_eq!(fetched_labels, item1.labels);
-    // }
+        let fetched_labels = manager.fetch_labels_for_item(&item1.uuid);
+        assert_eq!(fetched_labels, item1.labels);
+    }
 
-    // #[test]
-    // fn test_fetch_items_with_label() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    #[test]
+    fn test_fetch_items_with_label() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
 
-    //     let mut item1 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 1".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label.clone()]
-    //     };
-    //     let mut item2 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 2".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label.clone()]
-    //     };
-    //     let mut item3 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 3".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label.clone(), label2.clone()]
-    //     };
+        let mut item1 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 1".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label.clone()]
+        };
+        let mut item2 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 2".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label.clone()]
+        };
+        let mut item3 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 3".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label.clone(), label2.clone()]
+        };
 
-    //     let mut item4 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 4".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label2.clone()]
-    //     };
+        let mut item4 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 4".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label2.clone()]
+        };
 
-    //     item1.uuid = manager.create_item(&item1);
-    //     item2.uuid = manager.create_item(&item2);
-    //     item3.uuid = manager.create_item(&item3);
-    //     item4.uuid = manager.create_item(&item4);
+        let item1 = manager.create_and_fetch_item(&item1).expect("expected item1");
+        let item2 = manager.create_and_fetch_item(&item2).expect("expected item2");
+        let item3 = manager.create_and_fetch_item(&item3).expect("expected item3");
+        let item4 = manager.create_and_fetch_item(&item4).expect("expected item4");
 
-    //     let fetched_label1_items = manager.fetch_items_with_label(&label);
-    //     assert_eq!(fetched_label1_items, vec![item1, item2, item3.clone()]);
-    //     let fetched_label2_items = manager.fetch_items_with_label(&label2);
-    //     assert_eq!(fetched_label2_items, vec![item3, item4]);
-    // }
+        let fetched_label1_items = manager.fetch_items_with_label(&label);
+        assert_eq!(fetched_label1_items, vec![item1, item2, item3.clone()]);
+        let fetched_label2_items = manager.fetch_items_with_label(&label2);
+        assert_eq!(fetched_label2_items, vec![item3, item4]);
+    }
 
-    // #[test]
-    // fn test_update_item_add_label() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    #[test]
+    fn test_update_item_add_label() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-    //     let mut item1 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 1".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label, label2]
-    //     };
+        let mut item1 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 1".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label, label2]
+        };
 
-    //     item1.uuid = manager.create_item(&item1);
-    //     let mut new_labels = item1.labels.clone();
-    //     new_labels.push(label3);
+        let created_item = manager.create_and_fetch_item(&item1).expect("expected an item");
+        let mut new_labels = item1.labels.clone();
+        new_labels.push(label3);
 
-    //     manager.update_item(&item1, None, None, None, Some(&new_labels));
+        manager.update_item(&created_item, None, None, None, Some(&new_labels));
 
-    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-    //     assert_eq!(fetched_item, item1);
-    // }
+        let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
+        assert_eq!(fetched_item, created_item);
+    }
 
-    // #[test]
-    // fn test_update_item_remove_label() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    #[test]
+    fn test_update_item_remove_label() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-    //     let mut item1 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 1".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label, label2, label3]
-    //     };
+        let mut item1 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 1".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label, label2, label3]
+        };
 
-    //     item1.uuid = manager.create_item(&item1);
-    //     let mut new_labels = item1.labels.clone();
-    //     new_labels.remove(2);
+        let created_item = manager.create_and_fetch_item(&item1).expect("expected an item");
+        let mut new_labels = created_item.labels.clone();
+        new_labels.remove(2);
 
-    //     manager.update_item(&item1, None, None, None, Some(&new_labels));
+        manager.update_item(&created_item, None, None, None, Some(&new_labels));
 
-    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-    //     assert_eq!(fetched_item, item1);
-    // }
+        let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
+        assert_eq!(fetched_item, created_item);
+    }
 
-    // #[test]
-    // fn test_update_item_add_due_date() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    #[test]
+    fn test_update_item_add_due_date() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-    //     let date = now_utc().to_timespec();
-    //     let mut item1 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 1".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label, label2, label3]
-    //     };
+        let date = now_utc().to_timespec();
+        let mut item1 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 1".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label, label2, label3]
+        };
 
-    //     item1.uuid = manager.create_item(&item1);
+        let created_item = manager.create_and_fetch_item(&item1).expect("expected an item");
 
-    //     manager.update_item(&item1, None, Some(date), None, None);
+        manager.update_item(&created_item, None, Some(date), None, None);
+        let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
+        let due_date = fetched_item.due_date.expect("expected a due date");
+        assert_eq!(due_date.sec, date.sec);
+    }
 
-    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-    //     let due_date = fetched_item.due_date.expect("expected a due date");
-    //     assert_eq!(due_date.sec, item1.due_date.unwrap().sec);
-    // }
+    #[test]
+    fn test_update_item_change_name() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-    // #[test]
-    // fn test_update_item_change_name() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+        let date = now_utc().to_timespec();
+        let mut item1 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 1".to_string(),
+            due_date: Some(date),
+            completion_date: None,
+            labels: vec![label, label2, label3]
+        };
 
-    //     let date = now_utc().to_timespec();
-    //     let mut item1 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 1".to_string(),
-    //         due_date: Some(date),
-    //         completion_date: None,
-    //         labels: vec![label, label2, label3]
-    //     };
+        let created_item = manager.create_and_fetch_item(&item1).expect("expected an item");
+        manager.update_item(&created_item, Some("new name".to_string()), None, None, None);
 
-    //     item1.uuid = manager.create_item(&item1);
-    //     manager.update_item(&item1, Some("new name".to_string()), None, None, None);
+        let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
+        assert_eq!(fetched_item.name, created_item.name);
+    }
 
-    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-    //     assert_eq!(fetched_item.name, item1.name);
-    // }
+    #[test]
+    fn test_update_item_complete_item() {
+        let mut manager = list_manager();
+        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-    // #[test]
-    // fn test_update_item_complete_item() {
-    //     let mut manager = list_manager();
-    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+        let date = now_utc().to_timespec();
+        let mut item1 = Item {
+            id: None,
+            uuid: Uuid::nil(),
+            name: "test item 1".to_string(),
+            due_date: None,
+            completion_date: None,
+            labels: vec![label, label2, label3]
+        };
 
-    //     let date = now_utc().to_timespec();
-    //     let mut item1 = Item {
-    //         id: None,
-    //         uuid: "".to_string(),
-    //         name: "test item 1".to_string(),
-    //         due_date: None,
-    //         completion_date: None,
-    //         labels: vec![label, label2, label3]
-    //     };
+        let created_item = manager.create_and_fetch_item(&item1).expect("expected an item");
+        manager.update_item(&created_item, None, None, Some(date), None);
 
-    //     item1.uuid = manager.create_item(&item1);
-    //     manager.update_item(&item1, None, None, Some(date), None);
-
-    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-    //     let completion_date = fetched_item.completion_date.expect("expected a completion_date");
-    //     assert_eq!(completion_date.sec, date.sec);
-    // }
+        let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
+        let completion_date = fetched_item.completion_date.expect("expected a completion_date");
+        assert_eq!(completion_date.sec, date.sec);
+    }
 }

--- a/complex/cargo/list/src/lib.rs
+++ b/complex/cargo/list/src/lib.rs
@@ -120,7 +120,7 @@ impl ListManager {
             :where
             [?l :label/name ?name]
             [?l :label/color ?color]
-            [?i :item/labels ?l]
+            [?i :item/label ?l]
             [?i :item/uuid ?item_uuid]
         ]"#;
         let result = Arc::clone(&self.store).query_args(query, &[&(&"?item_uuid".to_string(), &item_uuid)])?;
@@ -133,23 +133,24 @@ impl ListManager {
     }
 
     pub fn create_items_table(&mut self) -> Result<(), list_errors::Error> {
-        let schema = r#"[{  :db/ident     :item/uuid
-            :db/valueType :db.type/uuid
+        let schema = r#"[
+        {   :db/ident       :item/uuid
+            :db/valueType   :db.type/uuid
             :db/cardinality :db.cardinality/one
-            :db/unique :db.unique/value
+            :db/unique      :db.unique/value
             :db/index true },
-        {  :db/ident     :item/name
-            :db/valueType :db.type/string
+        {   :db/ident       :item/name
+            :db/valueType   :db.type/string
             :db/cardinality :db.cardinality/one
-            :db/fulltext true  },
-        {  :db/ident     :item/due_date
-            :db/valueType :db.type/instant
+            :db/fulltext    true  },
+        {   :db/ident       :item/due_date
+            :db/valueType   :db.type/instant
             :db/cardinality :db.cardinality/one  },
-        {  :db/ident     :item/completion_date
-            :db/valueType :db.type/instant
+        {   :db/ident       :item/completion_date
+            :db/valueType   :db.type/instant
             :db/cardinality :db.cardinality/one  },
-        {  :db/ident     :item/labels
-            :db/valueType :db.type/ref
+        {   :db/ident       :item/label
+            :db/valueType   :db.type/ref
             :db/cardinality :db.cardinality/many }]"#;
         let _ = self.write_connection().transact(schema)?;
         Ok(())
@@ -160,7 +161,7 @@ impl ListManager {
             :in ?label
             :where
             [?eid :item/uuid ?uuid]
-            [?eid :item/labels ?l]
+            [?eid :item/label ?l]
             [?l :label/name ?label]
         ]"#;
         let result = Arc::clone(&self.store).query_args(query, &[&(&"?label".to_string(), &label.name)])?;
@@ -249,7 +250,7 @@ impl ListManager {
                 "#, &query, &micro_seconds);
         }
         if !label_str.is_empty() {
-            query = format!(r#"{0}:item/labels [{1}]
+            query = format!(r#"{0}:item/label [{1}]
                 "#, &query, &label_str);
         }
         query = format!("{0}}}]", &query);
@@ -299,14 +300,14 @@ impl ListManager {
                 format!("{}", label_id)
             }).collect::<Vec<String>>().join(", ");
             if !labels_to_add.is_empty() {
-                transaction.push(format!("[:db/add {0} :item/labels [{1}]]", &item_id.id, labels_to_add));
+                transaction.push(format!("[:db/add {0} :item/label [{1}]]", &item_id.id, labels_to_add));
             }
             let labels_to_remove = existing_labels.iter().filter(|label| !new_labels.contains(label) ).map(|label| {
                 let label_id = label.id.to_owned().unwrap().id;
                 format!("{}", label_id)
             }).collect::<Vec<String>>().join(", ");
             if !labels_to_remove.is_empty() {
-                transaction.push(format!("[:db/retract {0} :item/labels [{1}]]", &item_id.id, labels_to_remove));
+                transaction.push(format!("[:db/retract {0} :item/label [{1}]]", &item_id.id, labels_to_remove));
             }
         }
         let query = format!("[{0}]", transaction.join(""));

--- a/complex/cargo/list/src/lib.rs
+++ b/complex/cargo/list/src/lib.rs
@@ -9,10 +9,14 @@
 // specific language governing permissions and limitations under the License.
 
 extern crate libc;
+extern crate edn;
+extern crate mentat;
+extern crate mentat_core;
 extern crate rusqlite;
+extern crate store;
 extern crate time;
 extern crate uuid;
-extern crate store;
+
 extern crate ffi_utils;
 
 use libc::size_t;
@@ -21,8 +25,18 @@ use std::sync::{
     Arc,
 };
 
-use time::Timespec;
-use uuid::Uuid;
+use mentat::query::QueryResults;
+use mentat_core::{
+    TypedValue,
+    Uuid,
+};
+use time::{
+    at,
+    Timespec,
+    Tm,
+    TmFmt,
+};
+use uuid::UuidVersion;
 
 pub mod labels;
 pub mod items;
@@ -31,7 +45,6 @@ use labels::Label;
 use ffi_utils::strings::c_char_to_string;
 use items::Item;
 use store::Store;
-
 
 #[derive(Debug)]
 #[repr(C)]
@@ -54,116 +67,129 @@ impl ListManager {
     }
 
     pub fn create_labels_table(&mut self) {
-        let schema = r#"[
-            {:db/ident :label/name
-            :db/valueType :db.type/string
-            :db/cardinality :db.cardinality/one
-            :db.unique :db.unique/value
-            :db/fulltext true}
-
-            {:db/ident :label/color
-            :db/valueType :db.type/string
-            :db/cardinality :db.cardinality/one}
-
-            {:db/ident :label/items
-            :db/valueType :db.type/ref
-            :db/cardinality :db.cardinality/many}
-            ]
-            "#;
+        let schema = r#"[{  :db/ident     :label/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value
+    :db/fulltext true },
+ {  :db/ident     :label/color
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one },
+ {  :db/ident     :label/items
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many }]"#;
         let _ = self.write_connection().transact(schema);
     }
 
     pub fn create_label(&mut self, name: String, color: String) -> Option<Label> {
         let query = format!(r#"[{{
             :label/name "{0}"
-            :login/color "{1}"
+            :label/color "{1}"
             }}]"#, &name, &color);
-        let _ = self.write_connection().transact(&query);
+        println!("{:?}", query);
+        let res = self.write_connection().transact(&query);
+        println!("res: {:?}", res);
         self.fetch_label(&name)
     }
 
     pub fn fetch_label(&self, name: &String) -> Option<Label> {
-        let query = r#"[:find ?eid, ?name, ?color
-            :in $ ?name
+        let query = r#"[:find ?name, ?color
+            :in ?name
             :where
             [?eid :label/name ?name]
             [?eid :label/color ?color]
         ]"#;
-        let result = Arc::clone(&self.store).query(query, &[&(&"?name".to_string(), &name)]);
-        println!("{:?}", result);
-        None
+        let result = Arc::clone(&self.store).query_args(query, &[&(&"?name".to_string(), &name)]);
+        match result {
+            Ok(rel) => {
+                if let QueryResults::Rel(rows) = rel {
+                    if !rows.is_empty() {
+                        Label::from_row(&rows[0])
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            },
+            Err(e) => {
+                println!("Failed to fetch {}, {}", name, e);
+                None
+            },
+        }
     }
 
     pub fn fetch_labels(&self) -> Vec<Label> {
-        // let sql = r#"SELECT name, color
-        //              FROM labels"#;
-        // let conn = self.store.read_connection();
-        // let mut stmt = conn.prepare(sql).unwrap();
-        // let mut label_iter = stmt.query_map(&[], |row| {
-        //     Label {
-        //         name: row.get(0),
-        //         color: row.get(1)
-        //     }
-        // }).unwrap();
-
-        let mut label_list: Vec<Label> = Vec::new();
-        // while let Some(result) = label_iter.next() {
-        //     if let Some(mut label) = result.ok() {
-        //         label_list.push(label);
-        //     }
-        // }
-        label_list
+        let query = r#"[:find ?name, ?color
+            :where
+            [?eid :label/name ?name]
+            [?eid :label/color ?color]
+        ]"#;
+        println!("{:?}", query);
+        let result = Arc::clone(&self.store).query(query);
+        match result {
+            Ok(rel) => {
+                if let QueryResults::Rel(rows) = rel {
+                    rows.iter().map(|row| Label::from_row(&row).unwrap()).collect()
+                } else {
+                    vec![]
+                }
+            },
+            Err(e) => {
+                println!("Failed to fetch labels");
+                vec![]
+            },
+        }
     }
 
-    pub fn fetch_labels_for_item(&self, item_uuid: &String) -> Vec<Label> {
-        // let sql = r#"SELECT name, color
-        //              FROM labels JOIN item_labels on item_labels.item_uuid=?"#;
-        // let conn = self.store.read_connection();
-        // let mut stmt = conn.prepare(sql).unwrap();
-        // let mut label_iter = stmt.query_map(&[item_uuid], |row| {
-        //     Label {
-        //         name: row.get(0),
-        //         color: row.get(1)
-        //     }
-        // }).unwrap();
-
-        let mut label_list: Vec<Label> = Vec::new();
-        // while let Some(result) = label_iter.next() {
-        //     if let Some(mut label) = result.ok() {
-        //         label_list.push(label);
-        //     }
-        // }
-        label_list
+    pub fn fetch_labels_for_item(&self, item_uuid: &Uuid) -> Vec<Label> {
+        println!("fetch_labels_for_item");
+        let query = r#"[:find ?name, ?color
+            :in ?item_uuid
+            :where
+            [?l :label/name ?name]
+            [?l :label/color ?color]
+            [?l :label/items ?i]
+            [?i :item/uuid ?item_uuid]
+        ]"#;
+        println!("query {:?}, {:?}", query, item_uuid);
+        let result = Arc::clone(&self.store).query_args(query, &[&(&"?item_uuid".to_string(), &item_uuid)]);
+        match result {
+            Ok(rel) => {
+                if let QueryResults::Rel(rows) = rel {
+                    println!("rows {:?}", rows);
+                    rows.iter().map(|row| Label::from_row(&row).unwrap()).collect()
+                } else {
+                    println!("no labels for item {:?}", item_uuid);
+                    vec![]
+                }
+            },
+            Err(e) => {
+                println!("Failed to fetch labels for {:?}: {}", item_uuid, e);
+                vec![]
+            },
+        }
     }
 
     pub fn create_items_table(&mut self) {
-        let schema = r#"[
-            {:db/ident :item/uuid
+        let schema = r#"[{  :db/ident     :item/uuid
             :db/valueType :db.type/uuid
             :db/cardinality :db.cardinality/one
-            :db.unique :db.unique/identity
-            :db/index true}
-
-            {:db/ident :item/name
+            :db/unique :db.unique/identity
+            :db/index true },
+        {  :db/ident     :item/name
             :db/valueType :db.type/string
             :db/cardinality :db.cardinality/one
-            :db/fulltext true}
-
-            {:db/ident :item/due_date
+            :db/fulltext true  },
+        {  :db/ident     :item/due_date
             :db/valueType :db.type/instant
-            :db/cardinality :db.cardinality/one}
-
-            {:db/ident :item/completion_date
+            :db/cardinality :db.cardinality/one  },
+        {  :db/ident     :item/completion_date
             :db/valueType :db.type/instant
-            :db/cardinality :db.cardinality/one}
-
-            {:db/ident :label/labels
+            :db/cardinality :db.cardinality/one  },
+        {  :db/ident     :item/labels
             :db/valueType :db.type/ref
-            :db/cardinality :db.cardinality/many
-            db.unique :db.unique/identity
-            :db/index true}
-            ]
-            "#;
+            :db/cardinality :db.cardinality/many }]"#;
         let _ = self.write_connection().transact(schema);
     }
 
@@ -193,59 +219,87 @@ impl ListManager {
         item_list
     }
 
-    pub fn fetch_item(&self, uuid: &String) -> Option<Item> {
-        // let sql = r#"SELECT uuid, name, due_date, completion_date FROM items WHERE uuid=?"#;
-
-        // let conn = self.store.read_connection();
-        // let mut stmt = conn.prepare(sql).unwrap();
-        // let mut item_iter = stmt.query_map(&[uuid], |row| {
-        //     Item {
-        //         uuid: row.get(0),
-        //         name: row.get(1),
-        //         due_date: row.get(2),
-        //         completion_date: row.get(3),
-        //         labels: self.fetch_labels_for_item(uuid)
-        //     }
-        // }).unwrap();
-
-        // if let Some(result) = item_iter.next() {
-        //     result.ok()
-        // } else {
-        //     println!("No item found for uuid {:?}", uuid);
-        //     None
-        // }
-        None
+    pub fn fetch_item(&self, uuid: &Uuid) -> Option<Item> {
+        println!("fetching item {}", uuid);
+        let query = r#"[:find ?eid, ?uuid, ?name, ?due_date, ?completion_date
+            :in ?uuid
+            :where
+            [?eid :item/uuid ?uuid]
+            [?eid :item/name ?name]
+            [?eid :item/due_date ?due_date]
+            [?eid :item/completion_date ?completion_date]
+        ]"#;
+        println!("{:?} {:?}", query, uuid);
+        let result = Arc::clone(&self.store).query_args(query, &[&(&"?uuid".to_string(), &uuid)]);
+        match result {
+            Ok(rel) => {
+                if let QueryResults::Rel(rows) = rel {
+                    println!("rows {:?}", rows);
+                    if !rows.is_empty() {
+                        let mut item = Item::from_row(&rows[0]).unwrap();
+                        println!("fetching labels for item: {:?}", item);
+                        item.labels = self.fetch_labels_for_item(&uuid);
+                        println!("returning item: {:?}", item);
+                        Some(item)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            },
+            Err(e) => {
+                println!("Failed to fetch {}, {}", uuid, e);
+                None
+            },
+        }
     }
 
-    pub fn create_item(&mut self, item: &Item) -> Option<Item> {
+    pub fn create_item(&mut self, item: &Item) -> Uuid {
         let label_str = item.labels.iter().map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
-        let item_uuid = Uuid::new_v4().simple().to_string();
+        let tmp_uuid = uuid::Uuid::new_v4().hyphenated().to_string();
+        let item_uuid = Uuid::parse_str(&tmp_uuid).unwrap();
+        // println!("item uuid: {:?}", item_uuid);
         let mut query = format!(r#"[{{
-            :item/uuid "{0}"
+            :item/uuid #uuid "{0}"
             :item/name "{1}"
-            "#, &item_uuid, &(item.name));
+            "#, &item_uuid.hyphenated().to_string(), &(item.name));
         if let Some(due_date) = item.due_date {
-            query = format!(r#"{}:item/due_date "{:?}"
-                "#, &query, &due_date);
+            let micro_seconds = due_date.sec * 1000000;
+            query = format!(r#"{}:item/due_date #instmicros {}
+                "#, &query, &micro_seconds);
         }
         if let Some(completion_date) = item.completion_date {
-            query = format!(r#"{}:item/completion_date "{:?}"
-                "#, &query, &completion_date);
+            let micro_seconds = completion_date.sec * 1000000;
+            query = format!(r#"{}:item/completion_date #instmicros {}
+                "#, &query, &micro_seconds);
         }
         if !label_str.is_empty() {
             query = format!(r#"{0}:item/labels ["{1}"]
                 "#, &query, &label_str);
         }
         query = format!("{0}}}]", &query);
-        let _ = self.write_connection().transact(&query);
+        println!("query: {}", query);
+        let res = self.write_connection().transact(&query);
+        // println!("res: {:?}", res);
+        item_uuid
+    }
+
+    pub fn create_and_fetch_item(&mut self, item: &Item) -> Option<Item> {
+        println!("Creating item {:?}", item);
+        let item_uuid = self.create_item(&item);
+        println!("Fetching item {:?}", item_uuid);
         self.fetch_item(&item_uuid)
     }
 
-    pub fn update_item(&mut self, item: &Item, name: String, due_date: Option<Timespec>, completion_date: Option<Timespec>, labels: &Vec<Label>) {
+    pub fn update_item(&mut self, item: &Item, name: Option<String>, due_date: Option<Timespec>, completion_date: Option<Timespec>, labels: Option<&Vec<Label>>) {
         let item_id = item.id.expect("item must have ID to be updated");
         let mut transaction = vec![];
-        if item.name != name {
-            transaction.push(format!("[:db/add {0} :item/name {1}]", &item_id, name));
+
+        if let Some(name) = name {
+            if item.name != name {
+                transaction.push(format!("[:db/add {0} :item/name {1}]", &item_id, name));
+            }
         }
         if item.due_date != due_date {
             if let Some(date) = due_date {
@@ -263,15 +317,17 @@ impl ListManager {
             }
         }
 
-        let existing_labels = self.fetch_labels_for_item(&(item.uuid));
+        if let Some(new_labels) = labels {
+            let existing_labels = self.fetch_labels_for_item(&(item.uuid));
 
-        let labels_to_add = item.labels.iter().filter(|label| !existing_labels.contains(label) ).map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
-        if !labels_to_add.is_empty() {
-            transaction.push(format!("[:db/add {0} :item/labels [\"{1}\"]]", &item_id, labels_to_add));
-        }
-        let labels_to_remove = existing_labels.iter().filter(|label| !item.labels.contains(label) ).map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
-        if !labels_to_remove.is_empty() {
-            transaction.push(format!("[:db/retract {0} :item/labels [\"{1}\"]]", &item_id, labels_to_remove));
+            let labels_to_add = new_labels.iter().filter(|label| !existing_labels.contains(label) ).map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
+            if !labels_to_add.is_empty() {
+                transaction.push(format!("[:db/add {0} :item/labels [\"{1}\"]]", &item_id, labels_to_add));
+            }
+            let labels_to_remove = existing_labels.iter().filter(|label| !new_labels.contains(label) ).map(|label| label.name.to_owned()).collect::<Vec<String>>().join("\", \"");
+            if !labels_to_remove.is_empty() {
+                transaction.push(format!("[:db/retract {0} :item/labels [\"{1}\"]]", &item_id, labels_to_remove));
+            }
         }
         let query = format!("[{0}]", transaction.join(""));
         let _ = self.write_connection().transact(&query);
@@ -297,7 +353,7 @@ pub unsafe extern "C" fn list_manager_update_item(manager: *mut ListManager, ite
     let manager = &mut*manager;
     let item = &*item;
     let labels = &*labels;
-    let name = c_char_to_string(name);
+    let name = Some(c_char_to_string(name));
     let mut due: Option<Timespec>;
     if !due_date.is_null() {
         due = Some(Timespec::new(due_date as i64, 0));
@@ -310,7 +366,7 @@ pub unsafe extern "C" fn list_manager_update_item(manager: *mut ListManager, ite
     } else {
         completion = None;
     }
-    manager.update_item(item, name, due, completion, labels);
+    manager.update_item(item, name, due, completion, Some(labels));
 }
 
 #[no_mangle]
@@ -325,46 +381,68 @@ pub unsafe extern "C" fn list_manager_create_label(manager: *mut ListManager, na
 
 #[cfg(test)]
 mod test {
+    extern crate edn;
+
     use super::{
         Store,
         ListManager,
         Label,
         Item,
-        create_and_fetch_item,
     };
 
     use std::sync::Arc;
 
+    use mentat_core::Uuid;
     use time::now_utc;
 
+
     fn list_manager() -> ListManager {
-        let store = Arc::new(Store::new(None));
+        let store = Arc::new(Store::new(None).expect("Expected a store"));
         ListManager::new(store)
+    }
+
+    fn assert_ident_present(edn: edn::Value, namespace: &str, name: &str) -> bool {
+        match edn {
+            edn::Value::Vector(v) => {
+                let mut found = false;
+                for val in v.iter() {
+                    found = assert_ident_present(val.clone(), namespace, name);
+                    if found {
+                        break;
+                    }
+                }
+                found
+            },
+            edn::Value::Map(m) => {
+                let mut found = false;
+                for (key, val) in &m {
+                    if let edn::Value::NamespacedKeyword(ref kw) = *key {
+                        if kw.namespace == "db" && kw.name == "ident" {
+                            found = assert_ident_present(val.clone(), namespace, name);
+                            if found { break; }
+                        } else {
+                            continue
+                        }
+                    }
+                }
+                found
+            },
+            edn::Value::NamespacedKeyword(kw) => kw.namespace == namespace && kw.name == name,
+            _ => false
+        }
     }
 
     #[test]
     fn test_new_list_manager() {
         let manager = list_manager();
-        let sql = r#"SELECT count(name) FROM sqlite_master WHERE type='table' AND name=?"#;
-        let conn = manager.get_store().get_conn();
-        // test that items table has been created
-        let mut stmt = conn.prepare(sql).unwrap();
-        let tables = [&"items", &"labels", &"item_labels"];
-        for &table in tables.iter() {
-            let mut r = stmt.query(&[table]).unwrap();
-            match r.next() {
-                Some(Ok(row)) => {
-                    let count: i64 = row.get(0);
-                    assert_eq!(count, 1);
-                },
-                _ => assert!(false),
-            }
-        }
+        let schema = Arc::clone(&manager.store).fetch_schema();
+        assert_ident_present(schema.clone(), "label", "name");
+        assert_ident_present(schema, "list", "name");
     }
 
     #[test]
     fn test_create_label() {
-        let manager = list_manager();
+        let mut manager = list_manager();
         let l = Label {
             name: "test".to_string(),
             color: "#000000".to_string()
@@ -375,7 +453,7 @@ mod test {
 
     #[test]
     fn test_fetch_label() {
-        let manager = list_manager();
+        let mut manager = list_manager();
         let created_label = manager.create_label("test".to_string(), "#000000".to_string()).unwrap();
         let fetched_label = manager.fetch_label(&created_label.name).unwrap();
         assert_eq!(fetched_label, created_label);
@@ -386,7 +464,7 @@ mod test {
 
     #[test]
     fn test_fetch_labels() {
-        let manager = list_manager();
+        let mut manager = list_manager();
 
         let labels = ["label1".to_string(), "label2".to_string(), "label3".to_string()];
         for label in labels.iter() {
@@ -416,15 +494,18 @@ mod test {
 
         let date = now_utc().to_timespec();
         let i = Item {
-            uuid: "".to_string(),
+            id: None,
+            uuid: Uuid::nil(),
             name: "test item".to_string(),
             due_date: Some(date.clone()),
             completion_date: Some(date.clone()),
             labels: vec![label, label2]
         };
 
-        let item = create_and_fetch_item(&mut manager, &i).expect("expected an item");
-        assert!(item.uuid.len() > 0);
+        println!("creating and fetching item {:?}", i);
+
+        let item = manager.create_and_fetch_item(&i).expect("expected an item");
+        assert!(!item.uuid.is_nil());
         assert_eq!(item.name, i.name);
         let due_date = item.due_date.expect("expecting a due date");
         assert_eq!(due_date.sec, date.sec);
@@ -433,286 +514,292 @@ mod test {
         assert_eq!(item.labels, i.labels);
     }
 
-    #[test]
-    fn test_create_item_no_due_date() {
-        let mut manager = list_manager();
-        let l = Label {
-            name: "label1".to_string(),
-            color: "#000000".to_string()
-        };
-        let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
+    // #[test]
+    // fn test_create_item_no_due_date() {
+    //     let mut manager = list_manager();
+    //     let l = Label {
+    //         name: "label1".to_string(),
+    //         color: "#000000".to_string()
+    //     };
+    //     let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
 
-        let l2 = Label {
-            name: "label2".to_string(),
-            color: "#000000".to_string()
-        };
-        let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
+    //     let l2 = Label {
+    //         name: "label2".to_string(),
+    //         color: "#000000".to_string()
+    //     };
+    //     let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
 
-        let date = now_utc().to_timespec();
-        let i = Item {
-            uuid: "".to_string(),
-            name: "test item".to_string(),
-            due_date: None,
-            completion_date: Some(date.clone()),
-            labels: vec![label, label2]
-        };
+    //     let date = now_utc().to_timespec();
+    //     let i = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item".to_string(),
+    //         due_date: None,
+    //         completion_date: Some(date.clone()),
+    //         labels: vec![label, label2]
+    //     };
 
-        let item = create_and_fetch_item(&mut manager, &i).expect("expected an item");
-        assert!(item.uuid.len() > 0);
-        assert_eq!(item.name, i.name);
-        assert_eq!(item.due_date, i.due_date);
-        let completion_date = item.completion_date.expect("expecting a completion date");
-        assert_eq!(completion_date.sec, date.sec);
-        assert_eq!(item.labels, i.labels);
-    }
+    //     let item = manager.create_and_fetch_item(&i).expect("expected an item");
+    //     assert!(item.uuid.len() > 0);
+    //     assert_eq!(item.name, i.name);
+    //     assert_eq!(item.due_date, i.due_date);
+    //     let completion_date = item.completion_date.expect("expecting a completion date");
+    //     assert_eq!(completion_date.sec, date.sec);
+    //     assert_eq!(item.labels, i.labels);
+    // }
 
-    #[test]
-    fn test_create_item_no_completion_date() {
-        let mut manager = list_manager();
-        let l = Label {
-            name: "label1".to_string(),
-            color: "#000000".to_string()
-        };
-        let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
+    // #[test]
+    // fn test_create_item_no_completion_date() {
+    //     let mut manager = list_manager();
+    //     let l = Label {
+    //         name: "label1".to_string(),
+    //         color: "#000000".to_string()
+    //     };
+    //     let label = manager.create_label(l.name.clone(), l.color.clone()).unwrap();
 
-        let l2 = Label {
-            name: "label2".to_string(),
-            color: "#000000".to_string()
-        };
-        let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
+    //     let l2 = Label {
+    //         name: "label2".to_string(),
+    //         color: "#000000".to_string()
+    //     };
+    //     let label2 = manager.create_label(l2.name.clone(), l2.color.clone()).unwrap();
 
-        let date = now_utc().to_timespec();
-        let i = Item {
-            uuid: "".to_string(),
-            name: "test item".to_string(),
-            due_date: Some(date.clone()),
-            completion_date: None,
-            labels: vec![label, label2]
-        };
+    //     let date = now_utc().to_timespec();
+    //     let i = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item".to_string(),
+    //         due_date: Some(date.clone()),
+    //         completion_date: None,
+    //         labels: vec![label, label2]
+    //     };
 
-        let item = create_and_fetch_item(&mut manager, &i).expect("expected an item");
-        assert!(item.uuid.len() > 0);
-        assert_eq!(item.name, i.name);
-        let due_date = item.due_date.expect("expecting a due date");
-        assert_eq!(due_date.sec, date.sec);
-        assert_eq!(item.completion_date, i.completion_date);
-        assert_eq!(item.labels, i.labels);
-    }
+    //     let item = manager.create_and_fetch_item(&i).expect("expected an item");
+    //     assert!(item.uuid.len() > 0);
+    //     assert_eq!(item.name, i.name);
+    //     let due_date = item.due_date.expect("expecting a due date");
+    //     assert_eq!(due_date.sec, date.sec);
+    //     assert_eq!(item.completion_date, i.completion_date);
+    //     assert_eq!(item.labels, i.labels);
+    // }
 
-    #[test]
-    fn test_fetch_item() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let mut created_item = Item {
-            uuid: "".to_string(),
-            name: "test item".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label]
-        };
+    // #[test]
+    // fn test_fetch_item() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let mut created_item = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label]
+    //     };
 
-        created_item.uuid = manager.create_item(&created_item);
-        let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
-        assert_eq!(fetched_item, created_item);
+    //     created_item.uuid = manager.create_item(&created_item);
+    //     let fetched_item = manager.fetch_item(&created_item.uuid).expect("expected an item");
+    //     assert_eq!(fetched_item, created_item);
 
-        let fetched_item = manager.fetch_item(&"doesn't exist".to_string());
-        assert_eq!(fetched_item, None);
-    }
+    //     let fetched_item = manager.fetch_item(&"doesn't exist".to_string());
+    //     assert_eq!(fetched_item, None);
+    // }
 
-    #[test]
-    fn test_fetch_labels_for_item() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    // #[test]
+    // fn test_fetch_labels_for_item() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-        let mut item1 = Item {
-            uuid: "".to_string(),
-            name: "test item 1".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label, label2, label3]
-        };
+    //     let mut item1 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 1".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label, label2, label3]
+    //     };
 
-        item1.uuid = manager.create_item(&item1);
+    //     item1.uuid = manager.create_item(&item1);
 
-        let fetched_labels = manager.fetch_labels_for_item(&item1.uuid);
-        assert_eq!(fetched_labels, item1.labels);
-    }
+    //     let fetched_labels = manager.fetch_labels_for_item(&item1.uuid);
+    //     assert_eq!(fetched_labels, item1.labels);
+    // }
 
-    #[test]
-    fn test_fetch_items_with_label() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    // #[test]
+    // fn test_fetch_items_with_label() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
 
-        let mut item1 = Item {
-            uuid: "".to_string(),
-            name: "test item 1".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label.clone()]
-        };
-        let mut item2 = Item {
-            uuid: "".to_string(),
-            name: "test item 2".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label.clone()]
-        };
-        let mut item3 = Item {
-            uuid: "".to_string(),
-            name: "test item 3".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label.clone(), label2.clone()]
-        };
+    //     let mut item1 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 1".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label.clone()]
+    //     };
+    //     let mut item2 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 2".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label.clone()]
+    //     };
+    //     let mut item3 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 3".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label.clone(), label2.clone()]
+    //     };
 
-        let mut item4 = Item {
-            uuid: "".to_string(),
-            name: "test item 4".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label2.clone()]
-        };
+    //     let mut item4 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 4".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label2.clone()]
+    //     };
 
-        item1.uuid = manager.create_item(&item1);
-        item2.uuid = manager.create_item(&item2);
-        item3.uuid = manager.create_item(&item3);
-        item4.uuid = manager.create_item(&item4);
+    //     item1.uuid = manager.create_item(&item1);
+    //     item2.uuid = manager.create_item(&item2);
+    //     item3.uuid = manager.create_item(&item3);
+    //     item4.uuid = manager.create_item(&item4);
 
-        let fetched_label1_items = manager.fetch_items_with_label(&label);
-        assert_eq!(fetched_label1_items, vec![item1, item2, item3.clone()]);
-        let fetched_label2_items = manager.fetch_items_with_label(&label2);
-        assert_eq!(fetched_label2_items, vec![item3, item4]);
-    }
+    //     let fetched_label1_items = manager.fetch_items_with_label(&label);
+    //     assert_eq!(fetched_label1_items, vec![item1, item2, item3.clone()]);
+    //     let fetched_label2_items = manager.fetch_items_with_label(&label2);
+    //     assert_eq!(fetched_label2_items, vec![item3, item4]);
+    // }
 
-    #[test]
-    fn test_update_item_add_label() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    // #[test]
+    // fn test_update_item_add_label() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-        let mut item1 = Item {
-            uuid: "".to_string(),
-            name: "test item 1".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label, label2]
-        };
+    //     let mut item1 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 1".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label, label2]
+    //     };
 
-        item1.uuid = manager.create_item(&item1);
-        item1.labels.push(label3);
+    //     item1.uuid = manager.create_item(&item1);
+    //     let mut new_labels = item1.labels.clone();
+    //     new_labels.push(label3);
 
-        let existing_labels = manager.fetch_labels_for_item(&item1.uuid);
-        manager.update_item(&item1, existing_labels);
+    //     manager.update_item(&item1, None, None, None, Some(&new_labels));
 
-        let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-        assert_eq!(fetched_item, item1);
-    }
+    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
+    //     assert_eq!(fetched_item, item1);
+    // }
 
-    #[test]
-    fn test_update_item_remove_label() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    // #[test]
+    // fn test_update_item_remove_label() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-        let mut item1 = Item {
-            uuid: "".to_string(),
-            name: "test item 1".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label, label2, label3]
-        };
+    //     let mut item1 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 1".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label, label2, label3]
+    //     };
 
-        item1.uuid = manager.create_item(&item1);
-        item1.labels.remove(2);
+    //     item1.uuid = manager.create_item(&item1);
+    //     let mut new_labels = item1.labels.clone();
+    //     new_labels.remove(2);
 
-        let existing_labels = manager.fetch_labels_for_item(&item1.uuid);
-        manager.update_item(&item1, existing_labels);
+    //     manager.update_item(&item1, None, None, None, Some(&new_labels));
 
-        let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-        assert_eq!(fetched_item, item1);
-    }
+    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
+    //     assert_eq!(fetched_item, item1);
+    // }
 
-    #[test]
-    fn test_update_item_add_due_date() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    // #[test]
+    // fn test_update_item_add_due_date() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-        let mut item1 = Item {
-            uuid: "".to_string(),
-            name: "test item 1".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label, label2, label3]
-        };
+    //     let date = now_utc().to_timespec();
+    //     let mut item1 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 1".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label, label2, label3]
+    //     };
 
-        item1.uuid = manager.create_item(&item1);
-        item1.due_date = Some(now_utc().to_timespec());
+    //     item1.uuid = manager.create_item(&item1);
 
-        let existing_labels = manager.fetch_labels_for_item(&item1.uuid);
-        manager.update_item(&item1, existing_labels);
+    //     manager.update_item(&item1, None, Some(date), None, None);
 
-        let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-        let due_date = fetched_item.due_date.expect("expected a due date");
-        assert_eq!(due_date.sec, item1.due_date.unwrap().sec);
-    }
+    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
+    //     let due_date = fetched_item.due_date.expect("expected a due date");
+    //     assert_eq!(due_date.sec, item1.due_date.unwrap().sec);
+    // }
 
-    #[test]
-    fn test_update_item_change_name() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    // #[test]
+    // fn test_update_item_change_name() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-        let date = now_utc().to_timespec();
-        let mut item1 = Item {
-            uuid: "".to_string(),
-            name: "test item 1".to_string(),
-            due_date: Some(date),
-            completion_date: None,
-            labels: vec![label, label2, label3]
-        };
+    //     let date = now_utc().to_timespec();
+    //     let mut item1 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 1".to_string(),
+    //         due_date: Some(date),
+    //         completion_date: None,
+    //         labels: vec![label, label2, label3]
+    //     };
 
-        item1.uuid = manager.create_item(&item1);
-        item1.name = "new name".to_string();
+    //     item1.uuid = manager.create_item(&item1);
+    //     manager.update_item(&item1, Some("new name".to_string()), None, None, None);
 
-        let existing_labels = manager.fetch_labels_for_item(&item1.uuid);
-        manager.update_item(&item1, existing_labels);
+    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
+    //     assert_eq!(fetched_item.name, item1.name);
+    // }
 
-        let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-        assert_eq!(fetched_item.name, item1.name);
-    }
+    // #[test]
+    // fn test_update_item_complete_item() {
+    //     let mut manager = list_manager();
+    //     let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
+    //     let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
+    //     let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
 
-    #[test]
-    fn test_update_item_complete_item() {
-        let mut manager = list_manager();
-        let label = manager.create_label("label1".to_string(), "#000000".to_string()).unwrap();
-        let label2 = manager.create_label("label2".to_string(), "#000000".to_string()).unwrap();
-        let label3 = manager.create_label("label3".to_string(), "#000000".to_string()).unwrap();
+    //     let date = now_utc().to_timespec();
+    //     let mut item1 = Item {
+    //         id: None,
+    //         uuid: "".to_string(),
+    //         name: "test item 1".to_string(),
+    //         due_date: None,
+    //         completion_date: None,
+    //         labels: vec![label, label2, label3]
+    //     };
 
-        let date = now_utc().to_timespec();
-        let mut item1 = Item {
-            uuid: "".to_string(),
-            name: "test item 1".to_string(),
-            due_date: None,
-            completion_date: None,
-            labels: vec![label, label2, label3]
-        };
+    //     item1.uuid = manager.create_item(&item1);
+    //     manager.update_item(&item1, None, None, Some(date), None);
 
-        item1.uuid = manager.create_item(&item1);
-        item1.completion_date = Some(date);
-
-        let existing_labels = manager.fetch_labels_for_item(&item1.uuid);
-        manager.update_item(&item1, existing_labels);
-
-        let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
-        let completion_date = fetched_item.completion_date.expect("expected a completion_date");
-        assert_eq!(completion_date.sec, date.sec);
-    }
+    //     let fetched_item = manager.fetch_item(&item1.uuid).expect("expected an item");
+    //     let completion_date = fetched_item.completion_date.expect("expected a completion_date");
+    //     assert_eq!(completion_date.sec, date.sec);
+    // }
 }

--- a/complex/cargo/list/src/lib.rs
+++ b/complex/cargo/list/src/lib.rs
@@ -23,22 +23,11 @@ extern crate ffi_utils;
 
 use libc::size_t;
 use std::os::raw::c_char;
-use std::sync::{
-    Arc,
-};
+use std::sync::Arc;
 
 use mentat::query::QueryResults;
-use mentat_core::{
-    TypedValue,
-    Uuid,
-};
-use time::{
-    at,
-    Timespec,
-    Tm,
-    TmFmt,
-};
-use uuid::UuidVersion;
+use mentat_core::Uuid;
+use time::Timespec;
 
 pub mod labels;
 pub mod items;
@@ -49,7 +38,6 @@ use ffi_utils::strings::c_char_to_string;
 use items::Item;
 use labels::Label;
 use store::{
-    Entity,
     Store,
     ToInner
 };

--- a/complex/cargo/src/errors.rs
+++ b/complex/cargo/src/errors.rs
@@ -10,20 +10,16 @@
 
 #![allow(dead_code)]
 
-use rusqlite;
-
-use mentat::errors as mentat;
+use store::errors as store_error;
+use list::errors as list_error;
 
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;
     }
 
-    foreign_links {
-        Rusqlite(rusqlite::Error);
-    }
-
     links {
-        MentatError(mentat::Error, mentat::ErrorKind);
+        StoreError(store_error::Error, store_error::ErrorKind);
+        ListError(list_error::Error, list_error::ErrorKind);
     }
 }

--- a/complex/cargo/src/lib.rs
+++ b/complex/cargo/src/lib.rs
@@ -8,6 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#[macro_use] extern crate error_chain;
 extern crate ffi_utils;
 extern crate store;
 extern crate list;
@@ -19,6 +20,8 @@ use std::sync::{
     Arc,
 };
 
+mod errors;
+
 use ffi_utils::strings::c_char_to_string;
 use list::ListManager;
 use store::Store;
@@ -29,19 +32,20 @@ pub struct Toodle {
 }
 
 impl Toodle {
-    fn new(uri: String) -> Toodle {
-        let store = Arc::new(Store::new(uri).expect("expected a store"));
-        Toodle {
+    fn new(uri: String) -> Result<Toodle, errors::Error> {
+        let store = Arc::new(Store::new(uri)?);
+        Ok(Toodle {
             store: Arc::clone(&store),
-            list: Arc::new(ListManager::new(Arc::clone(&store)))
-        }
+            list: Arc::new(ListManager::new(Arc::clone(&store))?)
+        })
     }
 }
 
 #[no_mangle]
 pub extern "C" fn new_toodle(uri: *const c_char) -> *mut Toodle {
     let uri = c_char_to_string(uri);
-    Box::into_raw(Box::new(Toodle::new(uri)))
+    let toodle = Toodle::new(uri).expect("expected a toodle");
+    Box::into_raw(Box::new(toodle))
 }
 
 #[no_mangle]

--- a/complex/cargo/src/lib.rs
+++ b/complex/cargo/src/lib.rs
@@ -30,10 +30,10 @@ pub struct Toodle {
 
 impl Toodle {
     fn new(uri: String) -> Toodle {
-        let store = Arc::new(Store::new(uri));
+        let store = Arc::new(Store::new(uri).expect("expected a store"));
         Toodle {
-            store: store.clone(),
-            list: Arc::new(ListManager::new(store.clone()))
+            store: Arc::clone(&store),
+            list: Arc::new(ListManager::new(Arc::clone(&store)))
         }
     }
 }

--- a/complex/cargo/store/Cargo.toml
+++ b/complex/cargo/store/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 authors = ["Emily Toop <etoop@mozilla.com>"]
 
 [dependencies]
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 ordered-float = "0.5"
 time = "0.1.38"
-error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
+uuid = { version = "0.4", features = ["v4"] }
 
 [target.'cfg(target_os="android")'.dependencies]
 jni = { version = "0.5", default-features = false }

--- a/complex/cargo/store/Cargo.toml
+++ b/complex/cargo/store/Cargo.toml
@@ -3,6 +3,11 @@ name = "store"
 version = "0.1.0"
 authors = ["Emily Toop <etoop@mozilla.com>"]
 
+[dependencies]
+ordered-float = "0.5"
+time = "0.1.38"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
+
 [target.'cfg(target_os="android")'.dependencies]
 jni = { version = "0.5", default-features = false }
 

--- a/complex/cargo/store/Cargo.toml
+++ b/complex/cargo/store/Cargo.toml
@@ -11,5 +11,25 @@ version = "0.12"
 # System sqlite might be very old.
 features = ["bundled", "limits"]
 
+[dependencies.mentat]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
+
+[dependencies.edn]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
+
+[dependencies.mentat_query]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
+
+[dependencies.mentat_core]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
+
+[dependencies.mentat_db]
+git = "https://github.com/mozilla/mentat.git"
+rev = "5558820"
+
 [dependencies.ffi-utils]
 path = "../ffi-utils"

--- a/complex/cargo/store/src/errors.rs
+++ b/complex/cargo/store/src/errors.rs
@@ -1,0 +1,36 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#![allow(dead_code)]
+
+use rusqlite;
+
+use mentat::errors as mentat;
+
+error_chain! {
+    types {
+        Error, ErrorKind, ResultExt, Result;
+    }
+
+    foreign_links {
+        Rusqlite(rusqlite::Error);
+    }
+
+    links {
+        MentatError(mentat::Error, mentat::ErrorKind);
+    }
+
+    errors {
+        CommandParse(message: String) {
+            description("An error occured parsing the entered command")
+            display("{}", message)
+        }
+    }
+}

--- a/complex/cargo/store/src/lib.rs
+++ b/complex/cargo/store/src/lib.rs
@@ -8,9 +8,15 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+extern crate mentat;
+extern crate edn;
+extern crate mentat_query;
+extern crate mentat_core;
+extern crate mentat_db;
 extern crate rusqlite;
 extern crate ffi_utils;
 
+use std::fmt;
 use std::os::raw::{
     c_char
 };
@@ -18,6 +24,12 @@ use std::sync::{
     Arc,
 };
 
+use mentat::{
+    new_connection,
+};
+use mentat::conn::Conn;
+use mentat_db::types::TxReport;
+use mentat::query::QueryResults;
 use rusqlite::{
     Connection
 };
@@ -28,8 +40,9 @@ use ffi_utils::strings::c_char_to_string;
 #[repr(C)]
 /// Store containing a SQLite connection
 pub struct Store {
-    conn: Arc<Connection>,
-    uri: Option<String>,
+    handle: Arc<Connection>,
+    conn: Conn,
+    uri: String,
 }
 
 impl Drop for Store {
@@ -38,33 +51,52 @@ impl Drop for Store {
     }
 }
 
+impl fmt::Debug for Store {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Store at {:?}", self.uri)
+    }
+}
+
 impl Store {
     pub fn new<T>(uri: T) -> Self
     where T: Into<Option<String>> {
-        let uri_string = uri.into();
-        let c = match &uri_string {
-            &Some(ref u) => Connection::open(u.clone()).expect("Expected a connection for URI"),
-            &None => Connection::open_in_memory().expect("Expected an in memory connection"),
+        let uri_string = match &(uri.into()) {
+            &Some(ref u) => u,
+            &None => "",
         };
-        Store {
-            conn: Arc::new(c),
+        let mut h = try!(new_connection(&uri_string));
+        let c = try!(Conn::connect(&mut h));
+        Ok(Store {
+            handle: Arc::new(h),
+            conn:c,
             uri: uri_string,
-        }
+        })
     }
 
-    pub fn get_conn_mut(&mut self) -> &mut Connection {
-        Arc::get_mut(&mut self.conn).unwrap()
+    pub fn open(&mut self, uri: String) -> Result<(), mentat::errors::Error> {
+        self.handle = try!(new_connection(&uri));
+        self.conn = try!(Conn::connect(&mut self.handle));
+        self.uri = uri;
+        Ok(())
     }
 
-    pub fn get_conn(&self) -> Arc<Connection> {
-        Arc::clone(&self.conn)
+    pub fn query(&self, query: String) -> Result<QueryResults, mentat::errors::Error> {
+        Ok(self.conn.q_once(&self.handle, &query, None)?)
+    }
+
+    pub fn transact(&mut self, transaction: String) -> Result<TxReport, mentat::errors::Error> {
+        Ok(self.conn.transact(&mut self.handle, &transaction)?)
+    }
+
+    pub fn fetch_schema(&self) -> edn::Value {
+        self.conn.current_schema().to_edn_value()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn new_store(uri: *const c_char) -> *mut Arc<Store> {
+pub extern "C" fn new_store(uri: *const c_char) -> *mut Store {
     let uri = c_char_to_string(uri);
-    let store = Arc::new(Store::new(Some(uri)));
+    let store = Store::new(uri).expect("expected Store");
     Box::into_raw(Box::new(store))
 }
 

--- a/complex/cargo/store/src/lib.rs
+++ b/complex/cargo/store/src/lib.rs
@@ -22,20 +22,15 @@ extern crate uuid;
 
 extern crate ffi_utils;
 
-use std::any::{Any, TypeId};
 use std::fmt;
 use std::os::raw::{
     c_char
 };
 use std::rc::Rc;
-use std::sync::{
-    Arc,
-};
 
 use edn::{
     DateTime,
     FromMicros,
-    ToMicros,
     Utc,
     Uuid
 };

--- a/complex/cargo/store/src/lib.rs
+++ b/complex/cargo/store/src/lib.rs
@@ -67,15 +67,9 @@ pub trait ToTypedValue {
     fn to_typed_value(&self) -> Result<TypedValue, ()>;
 }
 
-impl ToTypedValue for String {
+impl<'a> ToTypedValue for &'a String {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
-        Ok(TypedValue::String(Rc::new(self.to_owned())))
-    }
-}
-
-impl ToTypedValue for str {
-    fn to_typed_value(&self) -> Result<TypedValue, ()> {
-        Ok(TypedValue::String(Rc::new(self.to_owned())))
+        Ok(TypedValue::String(Rc::new((*self).to_owned())))
     }
 }
 
@@ -83,40 +77,40 @@ pub struct Entity {
     id: Entid
 }
 
-impl ToTypedValue for Entity {
+impl<'a> ToTypedValue for &'a Entity {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
         Ok(TypedValue::Ref(self.id.clone()))
     }
 }
 
-impl ToTypedValue for bool {
+impl<'a> ToTypedValue for &'a bool {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
-        Ok(TypedValue::Boolean(self.clone()))
+        Ok(TypedValue::Boolean((*self).to_owned()))
     }
 }
 
-impl ToTypedValue for i64 {
+impl<'a> ToTypedValue for &'a i64 {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
-        Ok(TypedValue::Long(self.clone()))
+        Ok(TypedValue::Long((*self).to_owned()))
     }
 }
 
-impl ToTypedValue for f64 {
+impl<'a> ToTypedValue for &'a f64 {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
-        Ok(TypedValue::Double(OrderedFloat(self.clone())))
+        Ok(TypedValue::Double(OrderedFloat((*self).to_owned())))
     }
 }
 
-impl ToTypedValue for Timespec {
+impl<'a> ToTypedValue for &'a Timespec {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
         let micro_seconds = (self.sec / 1000000) + i64::from((self.nsec * 1000));
         Ok(TypedValue::Instant(DateTime::<Utc>::from_micros(micro_seconds)))
     }
 }
 
-impl ToTypedValue for Uuid {
+impl<'a> ToTypedValue for &'a Uuid {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
-        Ok(TypedValue::Uuid(self.clone()))
+        Ok(TypedValue::Uuid((*self).to_owned()))
     }
 }
 

--- a/complex/cargo/store/src/lib.rs
+++ b/complex/cargo/store/src/lib.rs
@@ -74,11 +74,30 @@ impl<'a> ToTypedValue for &'a String {
     }
 }
 
-pub struct Entity {
-    id: Entid
+impl ToTypedValue for String {
+    fn to_typed_value(&self) -> Result<TypedValue, ()> {
+        Ok(TypedValue::String(Rc::new((*self).to_owned())))
+    }
 }
 
-impl<'a> ToTypedValue for &'a Entity {
+#[derive(PartialEq, Clone, Debug)]
+pub struct Entity {
+    pub id: Entid
+}
+
+impl Entity {
+    fn new(id: Entid) -> Entity {
+        Entity { id: id}
+    }
+}
+
+impl std::fmt::Display for Entity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+impl ToTypedValue for Entity {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
         Ok(TypedValue::Ref(self.id.clone()))
     }
@@ -112,6 +131,60 @@ impl<'a> ToTypedValue for &'a Timespec {
 impl<'a> ToTypedValue for &'a mentat_core::Uuid {
     fn to_typed_value(&self) -> Result<TypedValue, ()> {
         Ok(TypedValue::Uuid((*self).to_owned()))
+    }
+}
+
+pub trait ToInner<T> {
+    fn to_inner(self) -> T;
+}
+
+impl ToInner<Option<Entity>> for TypedValue {
+    fn to_inner(self) -> Option<Entity> {
+        match self {
+            TypedValue::Ref(r) => Some(Entity{
+                id: r.clone(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl ToInner<Option<i64>> for TypedValue {
+    fn to_inner(self) -> Option<i64> {
+        match self {
+            TypedValue::Long(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+impl ToInner<String> for TypedValue {
+    fn to_inner(self) -> String {
+        match self {
+            TypedValue::String(s) => s.to_string(),
+            _ => String::new(),
+        }
+    }
+}
+
+impl ToInner<Uuid> for TypedValue {
+    fn to_inner(self) -> Uuid {
+        match self {
+            TypedValue::Uuid(u) => u,
+            _ => Uuid::nil(),
+        }
+    }
+}
+
+impl ToInner<Option<Timespec>> for TypedValue {
+    fn to_inner(self) -> Option<Timespec> {
+        match self {
+            TypedValue::Instant(v) => {
+                let timestamp = v.timestamp();
+                Some(Timespec::new(timestamp, 0))
+            },
+            _ => None,
+        }
     }
 }
 

--- a/complex/cargo/store/src/lib.rs
+++ b/complex/cargo/store/src/lib.rs
@@ -141,9 +141,7 @@ pub trait ToInner<T> {
 impl ToInner<Option<Entity>> for TypedValue {
     fn to_inner(self) -> Option<Entity> {
         match self {
-            TypedValue::Ref(r) => Some(Entity{
-                id: r.clone(),
-            }),
+            TypedValue::Ref(r) => Some(Entity::new(r.clone())),
             _ => None,
         }
     }
@@ -241,7 +239,6 @@ impl Store {
             ee.push((Variable::from_valid_name(&arg), val.to_typed_value().ok().unwrap()));
         }
         let i = QueryInputs::with_value_sequence(ee);
-        // convert inputs to QueryInputs
         Ok(self.conn.q_once(&self.handle, query, i)?)
     }
 


### PR DESCRIPTION
Moving the Store implementation from SQLite to mentat.

Involves:

* Replacing SQLite with Mentat in Store crate
* Add some helper traits to make dealing with Mentat Result and Query types easier.
* Moving `ListManager` over to using Datalog instead of SQL
* Updating tests
* Moving from returning options from functions in `ListManager` to properly returning `Result` types and dealing with Mentat errors.